### PR TITLE
Mark repository as legacy Rust reference

### DIFF
--- a/.github/workflows/legacy.yml
+++ b/.github/workflows/legacy.yml
@@ -1,0 +1,18 @@
+name: Legacy Reference
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  legacy:
+    name: legacy Rust reference marker
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: document legacy status
+        run: |
+          test -f Cargo.toml
+          grep -q "Legacy Reference" README.md
+          echo "kotoba-v2025 is intentionally kept as a legacy Rust reference."

--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
 # Kotoba: A Phonosemantic Digital Computing System
 
+## Legacy Reference
+
+`kotoba-v2025` is intentionally preserved as a historical Rust design/reference
+workspace. It is not part of the active Kotoba/CLJC migration path, and its
+Cargo workspace is expected to remain here for archaeology and comparison.
+
+Active language, CLI, db, git/rad, deploy, and contract authority should live in
+current Kotoba/CLJC/EDN repositories such as `kotoba-lang/kotoba`,
+`kotoba-lang/kotoba-lang`, and focused domain contract repos.
+
 Ἐν ἀρχῇ ἦν ὁ λόγος
 
 **Kotoba is a phonosemantic digital computing system where all computing, operating system, datastore, and self-evolution mechanisms are represented, reasoned, and executed using JSON-LD with OWL inference.**


### PR DESCRIPTION
## Summary
- mark kotoba-v2025 as an intentional legacy Rust reference in README
- add a lightweight CI marker that asserts the legacy README notice remains present
- keep Cargo/Rust content by design for historical comparison

## Validation
- python3 workflow YAML parse
- git diff --check